### PR TITLE
Add support for MinIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install Terrakube in a Kubernetes cluster you will need the following:
   - [Google Cloud Identity](https://dexidp.io/docs/connectors/google/)
   - [Github](https://dexidp.io/docs/connectors/github/)
   - [Gitlab](https://dexidp.io/docs/connectors/gitlab/)
-- Azure Storage Account, Amazon S3 bucket or GCP Bucket
+- Azure Storage Account, Amazon S3 bucket, GCP Bucket and MinIO(Using AWS Endpoint)
 - Supported database:
   - SQL Azure
   - PostgreSQL
@@ -131,7 +131,7 @@ To learn more about how to build the Dex configuration file please review the fo
 In order to use Terrakube you will have to define the one administrator group, for example:
 - TERRAKUBE_ADMIN
 
-Members of these groups are the only users inside terrakube that can create ***organizations*** and ***handle team access***, to define more than one admin group use the ***security.admins*** 
+Members of these groups are the only users inside terrakube that can create ***organizations*** and ***handle team access***
 
 Example:
 
@@ -164,6 +164,12 @@ To create the Aws S3 you can use the following [terraform module]() (Work in Pro
 Terrakube require an Storage bucket to save the state/output for the jobs and to save the terraform modules when using terraform CLI.
 
 To create the Gcp Storage you can use the following [terraform module]() (Work in Progress).
+
+#### 3.3 MinIO 
+
+Terrakube require an Storage bucket to save the state/output for the jobs and to save the terraform modules when using terraform CLI.
+
+To create the MinIO Storage you can use the following [terraform module]() (Work in Progress).
 
 ### 4. Build Yaml file
 
@@ -202,6 +208,11 @@ Once you have completed the above steps you can complete the file values.yaml to
 | storage.azure.storageAccountName          | No       | Azure storage account name                                             |
 | storage.azure.storageAccountResourceGroup | No       | Azure storage resource group                                           |
 | storage.azure.storageAccountAccessKey     | No       | Azure storage access key                                               |
+| storage.aws.accessKey                     | No       | Aws access key                                                         |
+| storage.aws.secretKey                     | No       | Aws secret key                                                         |
+| storage.aws.bucketName                    | No       | Aws bucket name                                                        |
+| storage.aws.region                        | No       | Aws region name (Example: us-east-1)                                   |
+| storage.aws.endpoint                      | No       | Setup custom endpoint (MinIO)                                          |
 | dex.enabled                               | No       | Enable Dex component                                                   |
 | dex.version                               | Yes      | Dex [version](https://github.com/dexidp/dex/releases)                  |
 | dex.replicaCount                          | Yes      |                                                                        |

--- a/examples/CognitoAuthentication-Example1.md
+++ b/examples/CognitoAuthentication-Example1.md
@@ -32,6 +32,7 @@ storage:
     secretKey: "<<CHANGE_THIS>>"
     bucketName: "<<CHANGE_THIS>>"
     region: "<<CHANGE_THIS>>"
+    #endpoint: "<<CHANGE_THIS>>" #MinIO support using S3 client
 
 ## Dex
 dex:

--- a/templates/secrets-api.yaml
+++ b/templates/secrets-api.yaml
@@ -38,6 +38,12 @@ stringData:
   AwsStorageSecretKey: '{{ .Values.storage.aws.secretKey }}'
   AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
   AwsStorageRegion: '{{ .Values.storage.aws.region }}'
+
+  {{- if and (.Values.storage.aws).endpoint }}
+  AwsEndpoint: '{{ .Values.storage.aws.endpoint }}'
+  {{ else }}
+  AwsEndpoint: ''
+  {{- end }}
   {{- end }}
 
   {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials  }}

--- a/templates/secrets-executor.yaml
+++ b/templates/secrets-executor.yaml
@@ -41,6 +41,11 @@ stringData:
   AwsTerraformOutputSecretKey: '{{ .Values.storage.aws.secretKey }}'
   AwsTerraformOutputBucketName: '{{ .Values.storage.aws.bucketName }}'
   AwsTerraformOutputRegion: '{{ .Values.storage.aws.region }}'
+  {{- if and (.Values.storage.aws).endpoint }}
+  AwsEndpoint: '{{ .Values.storage.aws.endpoint }}'
+  {{ else }}
+  AwsEndpoint: ''
+  {{- end }}
   {{- end }}
 
   {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials  }}

--- a/templates/secrets-registry.yaml
+++ b/templates/secrets-registry.yaml
@@ -29,6 +29,11 @@ stringData:
   AwsStorageSecretKey: '{{ .Values.storage.aws.secretKey }}'
   AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
   AwsStorageRegion: '{{ .Values.storage.aws.region }}'
+  {{- if and (.Values.storage.aws).endpoint }}
+  AwsEndpoint: '{{ .Values.storage.aws.endpoint }}'
+  {{ else }}
+  AwsEndpoint: ''
+  {{- end }}
   {{- end }}
 
   {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials  }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -79,6 +79,10 @@
               "region": {
                 "description": "AWS Region",
                 "type": "string"
+              },
+              "endpoint": {
+                "description": "Custom S3 Endpoint",
+                "type": "string"
               }
             }
           },


### PR DESCRIPTION
Adding support to use MinIO using a custom endpoint in AWS storage in Terrakube 2.7.0

```
## Terrakube Storage
storage:
  aws:
    accessKey: "XXXX"
    secretKey: "XXXX"
    bucketName: "XXXX"
    region: "us-east-1"
    endpoint: "hello.com"
```