### PR TITLE
Add support to add environment variables in pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ sample-values-mysql.yaml
 sample-values-dev365.yaml
 sample-values-dev365-dex.yaml
 sample-values-dev365-dex-github.yaml
+sample-values-dev365-dex-github-dd.yaml
 sample-values-dev365-cognito-dex.yaml
 sample-values-dev365-aws.yaml
 sample-values-dev365-gcp.yaml

--- a/templates/deployment-api.yaml
+++ b/templates/deployment-api.yaml
@@ -23,6 +23,10 @@ spec:
         {{- end }}
         ports:
         - containerPort: 8080
+        {{- with .Values.api.env }}
+        env:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: terrakube-api-secrets

--- a/templates/deployment-executor.yaml
+++ b/templates/deployment-executor.yaml
@@ -23,6 +23,10 @@ spec:
         {{- end }}
         ports:
         - containerPort: 8090
+        {{- with .Values.executor.env }}
+        env:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: terrakube-executor-secrets

--- a/templates/deployment-registry.yaml
+++ b/templates/deployment-registry.yaml
@@ -23,6 +23,10 @@ spec:
         {{- end }}
         ports:
         - containerPort: 8075
+        {{- with .Values.registry.env }}
+        env:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: terrakube-registry-secrets

--- a/values.schema.json
+++ b/values.schema.json
@@ -200,6 +200,12 @@
               "type": "object"
             }
           },
+          "env": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
           "properties": {
             "type": "object",
             "required": ["databaseType", "databaseHostname", "databaseName", "databaseUser", "databasePassword"],
@@ -263,6 +269,12 @@
               "type": "object"
             }
           },
+          "env": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
           "properties": {
             "type": "object",
             "required": ["toolsRepository", "toolsBranch"],
@@ -312,6 +324,12 @@
             "type": "array",
             "items": {
               "type": "object"
+            },
+            "env": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             }
           }
         }


### PR DESCRIPTION
Add new property to setup custom environement variables in pods.

```yaml
## API properties
api:
  enabled: true
  version: "2.7.0"
  replicaCount: "1"
  serviceType: "ClusterIP"
  env:
  - name: DEMO_GREETING
    value: "Hello from the environment"
  - name: DEMO_FAREWELL
    value: "Such a sweet sorrow"
  properties:
    databaseType: "H2"
    

## Executor properties
executor:
  enabled: true
  version: "2.7.0"  
  replicaCount: "1"
  serviceType: "ClusterIP"
  env:
  - name: DEMO_GREETING
    value: "Hello from the environment"
  - name: DEMO_FAREWELL
    value: "Such a sweet sorrow"
  properties:
    toolsRepository: "https://github.com/AzBuilder/terrakube-extensions"
    toolsBranch: "main"

## Registry properties
registry:
  enabled: true
  version: "2.7.0"
  replicaCount: "1"
  serviceType: "ClusterIP"
  env:
  - name: DEMO_GREETING
    value: "Hello from the environment"
  - name: DEMO_FAREWELL
    value: "Such a sweet sorrow"
```