### PR TITLE
Add support for custom CA certs and volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Once you have completed the above steps you can complete the file values.yaml to
 | security.dexClientScope                   | Yes      | Use "email openid profile offline_access groups"                       |
 | security.dexIssuerUri                     | Yes      | Should be "https://apiDomain/dex"                                      |
 | security.gcpCredentials                   | No       | JSON Credentials for Google Identity Authentication                    |
+| security.caCerts                          | No       | Custom CA certificates to be added at runtime                          |
 | storage.gcp.projectId                     | No       | GCP Project Id for the storage                                         |
 | storage.gcp.bucketName                    | No       | GCP Bucket name for the storage                                        |
 | storage.gcp.credentials                   | No       | GCP JSON Credentials for the storage                                   |
@@ -225,6 +226,9 @@ Once you have completed the above steps you can complete the file values.yaml to
 | api.version                               | Yes      | Terrakube API version                                                  |
 | api.replicaCount                          | Yes      |                                                                        |
 | api.serviceType                           | Yes      |                                                                        |
+| api.env                                   | No       |                                                                        |
+| api.volumes                               | No       |                                                                        |
+| api.volumeMounts                          | No       |                                                                        |
 | api.properties.databaseType               | Yes      | H2/SQL_AZURE/POSTGRESQL/MYSQL                                          |
 | api.properties.databaseHostname           | No       |                                                                        |
 | api.properties.databaseName               | No       |                                                                        |
@@ -234,12 +238,18 @@ Once you have completed the above steps you can complete the file values.yaml to
 | executor.version                          | Yes      | Terrakube Executor version                                             |
 | executor.replicaCount                     | Yes      |                                                                        |
 | executor.serviceType                      | Yes      | ClusterIP/NodePort/LoadBalancer/ExternalName                           |
+| executor.env                              | No       |                                                                        |
+| executor.volumes                          | No       |                                                                        |
+| executor.volumeMounts                     | No       |                                                                        |
 | executor.properties.toolsRepository       | Yes      | Example: https://github.com/AzBuilder/terrakube-extensions             |
 | executor.properties.toolsBranch           | Yes      | Example: main                                                          |
 | registry.enabled                          | Yes      |                                                                        |
 | registry.version                          | Yes      |                                                                        |
 | registry.replicaCount                     | Yes      |                                                                        |
 | registry.serviceType                      | Yes      | ClusterIP/NodePort/LoadBalancer/ExternalName                           |
+| registry.env                              | No       |                                                                        |
+| registry.volumes                          | No       |                                                                        |
+| registry.volumeMounts                     | No       |                                                                        |
 | ui.enabled                                | Yes      | true/false                                                             |
 | ui.version                                | Yes      |                                                                        |
 | ui.replicaCount                           | Yes      |                                                                        |
@@ -308,7 +318,123 @@ api:
     databaseType: "H2"
 ```
 
-### 5. Deploy Terrakube using helm chart
+### 5. Custom CA certificates at runtime
+
+To add custom CA certificate to Terrakube components use the folowing configuration example:
+
+Example property ***security.caCerts***
+
+```
+security:
+  .....
+  caCerts:
+    terrakubeDemo1.pem: |
+      -----BEGIN CERTIFICATE-----
+      
+      CERTIFICATE DATA
+
+      -----END CERTIFICATE-----
+    terrakubeDemo2.pem: |
+      -----BEGIN CERTIFICATE-----
+      
+      CERTIFICATE DATA
+
+      -----END CERTIFICATE-----
+  ....
+```
+
+Terrakube components configuration with custom CA certificates:
+
+```yaml
+## API properties
+api:
+  enabled: true
+  version: "2.7.0"
+  replicaCount: "1"
+  serviceType: "ClusterIP"
+  env:
+  - name: SERVICE_BINDING_ROOT
+    value: /mnt/platform/bindings
+  volumes:
+    - name: ca-certs
+      secret:
+        secretName: terrakube-ca-secrets
+        items:
+        - key: "terrakubeDemo1.pem"
+          path: "terrakubeDemo1.pem"
+        - key: "terrakubeDemo2.pem"
+          path: "terrakubeDemo2.pem"
+        - key: "type"
+          path: "type"
+  volumeMounts:
+  - name: ca-certs
+    mountPath: /mnt/platform/bindings/ca-certificates
+    readOnly: true
+  properties:
+    databaseType: "H2"
+    
+
+## Executor properties
+executor:
+  enabled: true
+  version: "2.7.0"  
+  replicaCount: "1"
+  serviceType: "ClusterIP"
+  env:
+  - name: SERVICE_BINDING_ROOT
+    value: /mnt/platform/bindings
+  volumes:
+    - name: ca-certs
+      secret:
+        secretName: terrakube-ca-secrets
+        items:
+        - key: "terrakubeDemo1.pem"
+          path: "terrakubeDemo1.pem"
+        - key: "terrakubeDemo2.pem"
+          path: "terrakubeDemo2.pem"
+        - key: "type"
+          path: "type"
+  volumeMounts:
+  - name: ca-certs
+    mountPath: /mnt/platform/bindings/ca-certificates
+    readOnly: true
+  properties:
+    toolsRepository: "https://github.com/AzBuilder/terrakube-extensions"
+    toolsBranch: "main"
+
+## Registry properties
+registry:
+  enabled: true
+  version: "2.7.0"
+  replicaCount: "1"
+  serviceType: "ClusterIP"
+  env:
+  - name: SERVICE_BINDING_ROOT
+    value: /mnt/platform/bindings
+  volumes:
+    - name: ca-certs
+      secret:
+        secretName: terrakube-ca-secrets
+        items:
+        - key: "terrakubeDemo1.pem"
+          path: "terrakubeDemo1.pem"
+        - key: "terrakubeDemo2.pem"
+          path: "terrakubeDemo2.pem"
+        - key: "type"
+          path: "type"
+  volumeMounts:
+  - name: ca-certs
+    mountPath: /mnt/platform/bindings/ca-certificates
+    readOnly: true
+```
+
+If the configuration is correct the pods log will show something like this:
+
+```
+Added 2 additional CA certificate(s) to system truststore
+```
+
+### 6. Deploy Terrakube using helm chart
 
 Now you have all the information to deploy Terrakube, you can use the following example:
 

--- a/templates/deployment-api.yaml
+++ b/templates/deployment-api.yaml
@@ -27,6 +27,10 @@ spec:
         env:
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        volumeMounts:
+          {{- with .Values.api.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         envFrom:
         - secretRef:
             name: terrakube-api-secrets
@@ -59,5 +63,9 @@ spec:
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.volumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{ end }}

--- a/templates/deployment-executor.yaml
+++ b/templates/deployment-executor.yaml
@@ -27,6 +27,10 @@ spec:
         env:
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        volumeMounts:
+          {{- with .Values.executor.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         envFrom:
         - secretRef:
             name: terrakube-executor-secrets
@@ -59,5 +63,9 @@ spec:
       {{- with .Values.executor.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executor.volumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{ end }}

--- a/templates/deployment-registry.yaml
+++ b/templates/deployment-registry.yaml
@@ -27,6 +27,10 @@ spec:
         env:
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        volumeMounts:
+          {{- with .Values.registry.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         envFrom:
         - secretRef:
             name: terrakube-registry-secrets
@@ -59,5 +63,9 @@ spec:
       {{- with .Values.registry.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.registry.volumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{ end }}

--- a/templates/secrets-certs.yaml
+++ b/templates/secrets-certs.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: terrakube-ca-secrets
+type: Opaque
+stringData: 
+  type: |
+    ca-certificates
+  
+  {{- with .Values.security.caCerts }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -36,6 +36,12 @@
           "adminGroup": {
             "description": "Terrakube Administrators Group",
             "type": "string"
+          },
+          "caCerts": {
+            "type": "object",
+            "items": {
+              "type": "object"
+            }
           }
         }
       },
@@ -206,6 +212,18 @@
               "type": "object"
             }
           },
+          "volumes": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "volumeMounts": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
           "properties": {
             "type": "object",
             "required": ["databaseType", "databaseHostname", "databaseName", "databaseUser", "databasePassword"],
@@ -275,6 +293,18 @@
               "type": "object"
             }
           },
+          "volumes": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "volumeMounts": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
           "properties": {
             "type": "object",
             "required": ["toolsRepository", "toolsBranch"],
@@ -326,6 +356,18 @@
               "type": "object"
             },
             "env": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "volumes": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "volumeMounts": {
               "type": "array",
               "items": {
                 "type": "object"


### PR DESCRIPTION
Adding support to add volumes in terrakube components.

Adding support to add custom custom ca certificates using property ***security.caCerts***

```
security:
  adminGroup: "TERRAKUBE_ADMIN"
  patSecret: "XXXXX"
  internalSecret: "XXXXXX"
  dexClientId: "microsoft"
  dexClientScope: "email openid profile offline_access groups"
  dexIssuerUri: "XXXXXX"
  caCerts:
    terrakubeDemo1.pem: |
      -----BEGIN CERTIFICATE-----
      
      XXX

      -----END CERTIFICATE-----
    terrakubeDemo2.pem: |
      -----BEGIN CERTIFICATE-----
      
      XXX

      -----END CERTIFICATE-----
```

Terrakube components configuration with custom CA certificates:

```yaml
## API properties
api:
  enabled: true
  version: "2.7.0"
  replicaCount: "1"
  serviceType: "ClusterIP"
  env:
  - name: SERVICE_BINDING_ROOT
    value: /mnt/platform/bindings
  volumes:
    - name: ca-certs
      secret:
        secretName: terrakube-ca-secrets
        items:
        - key: "terrakubeDemo1.pem"
          path: "terrakubeDemo1.pem"
        - key: "terrakubeDemo2.pem"
          path: "terrakubeDemo2.pem"
        - key: "type"
          path: "type"
  volumeMounts:
  - name: ca-certs
    mountPath: /mnt/platform/bindings/ca-certificates
    readOnly: true
  properties:
    databaseType: "H2"
    

## Executor properties
executor:
  enabled: true
  version: "2.7.0"  
  replicaCount: "1"
  serviceType: "ClusterIP"
  env:
  - name: SERVICE_BINDING_ROOT
    value: /mnt/platform/bindings
  volumes:
    - name: ca-certs
      secret:
        secretName: terrakube-ca-secrets
        items:
        - key: "terrakubeDemo1.pem"
          path: "terrakubeDemo1.pem"
        - key: "terrakubeDemo2.pem"
          path: "terrakubeDemo2.pem"
        - key: "type"
          path: "type"
  volumeMounts:
  - name: ca-certs
    mountPath: /mnt/platform/bindings/ca-certificates
    readOnly: true
  properties:
    toolsRepository: "https://github.com/AzBuilder/terrakube-extensions"
    toolsBranch: "main"

## Registry properties
registry:
  enabled: true
  version: "2.7.0"
  replicaCount: "1"
  serviceType: "ClusterIP"
  env:
  - name: SERVICE_BINDING_ROOT
    value: /mnt/platform/bindings
  volumes:
    - name: ca-certs
      secret:
        secretName: terrakube-ca-secrets
        items:
        - key: "terrakubeDemo1.pem"
          path: "terrakubeDemo1.pem"
        - key: "terrakubeDemo2.pem"
          path: "terrakubeDemo2.pem"
        - key: "type"
          path: "type"
  volumeMounts:
  - name: ca-certs
    mountPath: /mnt/platform/bindings/ca-certificates
    readOnly: true
```

If the configuration is correct the pods log will show something like:

![image](https://user-images.githubusercontent.com/4461895/193420111-eaaf7e6f-8bd1-4d6d-9f26-d477a0918302.png)
