### PR TITLE
Using bitnami openldap image

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.1
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-openldap.yaml
+++ b/charts/terrakube/templates/deployment-openldap.yaml
@@ -17,16 +17,21 @@ spec:
     spec:
       containers:
       - name: terrakube-openldap
-        image: osixia/openldap:1.4.0
-        args: ["--copy-service"]
+        image: bitnami/openldap:2.6.4-debian-11-r4
         env:
-        - name: LDAP_TLS_VERIFY_CLIENT
-          value: "try"
+        - name: LDAP_ADMIN_USERNAME
+          value: "admin"
+        - name: LDAP_ADMIN_PASSWORD
+          value: "admin"
+        - name: LDAP_ROOT
+          value: "dc=example,dc=org"
+        - name: LDAP_CUSTOM_LDIF_DIR
+          value: "/ldifs"
         ports:
-        - containerPort: 389
+        - containerPort: 1389
         volumeMounts:
         - name: openldap-config
-          mountPath: "/container/service/slapd/assets/config/bootstrap/ldif/custom/config-ldap.ldif"
+          mountPath: "/ldifs/config-ldap.ldif"
           subPath: "config-ldap.ldif"
           readOnly: true
       volumes:

--- a/charts/terrakube/templates/secret-openldap.yaml
+++ b/charts/terrakube/templates/secret-openldap.yaml
@@ -6,44 +6,38 @@ metadata:
 type: Opaque
 stringData:
   config-ldap.ldif: |
-    # Already included in default config of Docker image osixia/openldap:1.4.0.
-    #
-    # dn: dc=example,dc=org
-    # objectClass: dcObject
-    # objectClass: organization
-    # o: Example Company
-    # dc: example
+    dn: dc=example,dc=org
+    dc: example
+    objectClass: dcObject
+    objectClass: organization
+    o: Example, Inc
 
-    dn: ou=People,dc=example,dc=org
-    objectClass: organizationalUnit
-    ou: People
+    dn: ou=users,dc=example,dc=org
+    ou: users
+    objectClass: organizationalunit
 
-    dn: cn=lester,ou=People,dc=example,dc=org
-    objectClass: person
+    dn: cn=lester,ou=users,dc=example,dc=org
     objectClass: inetOrgPerson
     sn: Parkinson
     cn: Lester
     mail: admin@example.com
     userpassword: admin
 
-    dn: cn=grady,ou=People,dc=example,dc=org
-    objectClass: person
+    dn: cn=grady,ou=users,dc=example,dc=org
     objectClass: inetOrgPerson
     sn: Chambers
     cn: Grady
     mail: aws@example.com
     userpassword: azure
 
-    dn: cn=saarah,ou=People,dc=example,dc=org
-    objectClass: person
+    dn: cn=saarah,ou=users,dc=example,dc=org
     objectClass: inetOrgPerson
     sn: Lott
     cn: Saarah
     mail: azure@example.com
     userpassword: aws
 
-    dn: cn=eugene,ou=People,dc=example,dc=org
-    objectClass: person
+    dn: cn=eugene,ou=users,dc=example,dc=org
     objectClass: inetOrgPerson
     sn: Monaghan
     cn: Eugene
@@ -59,26 +53,26 @@ stringData:
     dn: cn=TERRAKUBE_ADMIN,ou=Groups,dc=example,dc=org
     objectClass: groupOfNames
     cn: TERRAKUBE_ADMIN
-    member: cn=lester,ou=People,dc=example,dc=org
+    member: cn=lester,ou=users,dc=example,dc=org
 
     dn: cn=TERRAKUBE_DEVELOPERS,ou=Groups,dc=example,dc=org
     objectClass: groupOfNames
     cn: TERRAKUBE_DEVELOPERS
-    member: cn=lester,ou=People,dc=example,dc=org
+    member: cn=lester,ou=users,dc=example,dc=org
 
     dn: cn=AZURE_DEVELOPERS,ou=Groups,dc=example,dc=org
     objectClass: groupOfNames
     cn: AZURE_DEVELOPERS
-    member: cn=saarah,ou=People,dc=example,dc=org
+    member: cn=saarah,ou=users,dc=example,dc=org
 
     dn: cn=AWS_DEVELOPERS,ou=Groups,dc=example,dc=org
     objectClass: groupOfNames
     cn: AWS_DEVELOPERS
-    member: cn=grady,ou=People,dc=example,dc=org
+    member: cn=grady,ou=users,dc=example,dc=org
 
     dn: cn=GCP_DEVELOPERS,ou=Groups,dc=example,dc=org
     objectClass: groupOfNames
     cn: GCP_DEVELOPERS
-    member: cn=eugene,ou=People,dc=example,dc=org
+    member: cn=eugene,ou=users,dc=example,dc=org
 
 {{ end }}

--- a/charts/terrakube/templates/service-openldap.yaml
+++ b/charts/terrakube/templates/service-openldap.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   type: "ClusterIP"
   ports:
-  - port: 389
-    targetPort: 389
+  - port: 1389
+    targetPort: 1389
   selector:
     app: terrakube-openldap
 {{ end }}

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -35,7 +35,7 @@ dex:
         # The following configurations seem to work with OpenLDAP:
         #
         # 1) Plain LDAP, without TLS:
-        host: terrakube-openldap-service:389
+        host: terrakube-openldap-service:1389
         insecureNoSSL: true
         #
         # 2) LDAPS without certificate validation:
@@ -57,7 +57,7 @@ dex:
         usernamePrompt: Email Address
 
         userSearch:
-          baseDN: ou=People,dc=example,dc=org
+          baseDN: ou=users,dc=example,dc=org
           filter: "(objectClass=person)"
           username: mail
           # "DN" (case sensitive) is a special attribute name. It indicates that


### PR DESCRIPTION
The openldap container will be using bitnami/openldap:2.6.4-debian-11-r4 this container is not running as root like osixia/openldap:1.4.0 this is usefull when running in minikube or any other kubernetes cluster