### PR TITLE
Support to enable/disable ingress tls hosts setting

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.1
+version: 3.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/ingress-api.yaml
+++ b/charts/terrakube/templates/ingress-api.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{ if .Values.ingress.useTls }}
+  {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:
     - {{ .Values.ingress.api.domain | quote }}

--- a/charts/terrakube/templates/ingress-registry.yaml
+++ b/charts/terrakube/templates/ingress-registry.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{ if .Values.ingress.useTls }}
+  {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:
     - {{ .Values.ingress.registry.domain | quote}}

--- a/charts/terrakube/templates/ingress-ui.yaml
+++ b/charts/terrakube/templates/ingress-ui.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{ if .Values.ingress.useTls }}
+  {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:
     - {{ .Values.ingress.ui.domain | quote }}

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -424,6 +424,10 @@
             "description": "Enable Https Ingress",
                 "type": "boolean"
           },
+          "includeTlsHosts": {
+            "description": "Include spec.tls.hosts inside ingress config",
+                "type": "boolean"
+          },
           "ui": {
             "type": "object",
             "required": ["enabled", "annotations", "path", "pathType"],

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -197,6 +197,7 @@ ui:
 ## Ingress properties
 ingress:
   useTls: false
+  includeTlsHosts: true
   ui:
     enabled: true
     domain: "terrakube-ui.minikube.net"


### PR DESCRIPTION
Adding support to enable/disable spec.tls.hosts. This is require for GKE using Google Kubernetes native Ingress

```yaml
## Ingress properties
ingress:
  includeTlsHosts: true
```

