### PR TITLE
Fix deprecated annotations message

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.9.1
+version: 3.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -223,40 +223,37 @@ ui:
 ingress:
   useTls: false
   includeTlsHosts: true
+  ingressClassName: nginx
   ui:
     enabled: true
     domain: "terrakube-ui.minikube.net"
-    path: "/(.*)"
+    path: "/"
     pathType: "Prefix"
     tlsSecretName: tls-secret-ui-terrakube
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/use-regex: "true"
   api:
     enabled: true
     domain: "terrakube-api.minikube.net"
-    path: "/(.*)"
+    path: "/"
     pathType: "Prefix"
     tlsSecretName: tls-secret-api-terrakube
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header Authorization $http_authorization;"
   registry:
     enabled: true
     domain: "terrakube-reg.minikube.net"
-    path: "/(.*)"
+    path: "/"
     pathType: "Prefix"
     tlsSecretName: tls-secret-reg-terrakube
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header Authorization $http_authorization;"
   dex:
     enabled: true
-    path: "/dex/(.*)"
+    path: "/dex/"
     pathType: "Prefix"
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header Authorization $http_authorization;"

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -223,7 +223,6 @@ ui:
 ingress:
   useTls: false
   includeTlsHosts: true
-  ingressClassName: nginx
   ui:
     enabled: true
     domain: "terrakube-ui.minikube.net"


### PR DESCRIPTION
Remove deprecated annotations.

Now when running the helm chart  install it wont show the deprecated annotations message.

Server Info:
```bash
serverVersion:
  buildDate: "2023-07-19T12:14:49Z"
  compiler: gc
  gitCommit: fa3d7990104d7c1f16943a67f11b154b71f6a132
  gitTreeState: clean
  gitVersion: v1.27.4
  goVersion: go1.20.6
  major: "1"
  minor: "27"
  platform: linux/amd64
```
Helm install command:

```
helm install terrakube ./charts/terrakube/ -n terrakube
NAME: terrakube
LAST DEPLOYED: Mon Oct  9 15:18:26 2023
NAMESPACE: terrakube
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

Fix #80 