### PR TITLE
feat(ingress): Add `ingressClassName` to ingress of UI/API/REGISTRY

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,18 +301,21 @@ Once you have completed the above steps you can complete the file values.yaml to
 | ui.serviceType                            | Yes      | ClusterIP/NodePort/LoadBalancer/ExternalName                           |
 | ui.securityContext                        | No       | Fill securityContext field                                             |
 | ui.containerSecurityContext               | No       | Fill securityContext field in the container spec                       |
+| ingress.ui.ingressClassName               | Yes      | Default is set to nginx                                                |
 | ingress.ui.useTls                         | Yes      | true/false                                                             |
 | ingress.ui.enabled                        | Yes      | true/false                                                             |
 | ingress.ui.domain                         | Yes      |                                                                        |
 | ingress.ui.path                           | Yes      | ImplementationSpecific/Exact/Prefix                                    |
 | ingress.ui.pathType                       | Yes      |                                                                        |
 | ingress.ui.annotations                    | Yes      | Ingress annotations                                                    |
+| ingress.api.ingressClassName              | Yes      | Default is set to nginx                                                |
 | ingress.api.useTls                        | Yes      |                                                                        |
 | ingress.api.enabled                       | Yes      |                                                                        |
 | ingress.api.domain                        | Yes      |                                                                        |
 | ingress.api.path                          | Yes      |                                                                        |
 | ingress.api.pathType                      | Yes      | ImplementationSpecific/Exact/Prefix                                    |
 | ingress.api.annotations                   | Yes      | Ingress annotations                                                    |
+| ingress.registry.ingressClassName         | Yes      | Default is set to nginx                                                |
 | ingress.registry.useTls                   | Yes      |                                                                        |
 | ingress.registry.enabled                  | Yes      |                                                                        |
 | ingress.registry.domain                   | Yes      |                                                                        |

--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.2
+version: 3.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/ingress-api.yaml
+++ b/charts/terrakube/templates/ingress-api.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.registry.ingressClassName | nginx }}
   {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:

--- a/charts/terrakube/templates/ingress-api.yaml
+++ b/charts/terrakube/templates/ingress-api.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.registry.ingressClassName | nginx }}
+  ingressClassName: {{ .Values.ingress.api.ingressClassName | nginx }}
   {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:

--- a/charts/terrakube/templates/ingress-registry.yaml
+++ b/charts/terrakube/templates/ingress-registry.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.registry.ingressClassName | nginx }}
   {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:

--- a/charts/terrakube/templates/ingress-ui.yaml
+++ b/charts/terrakube/templates/ingress-ui.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.ui.ingressClassName | nginx }}
   {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -248,6 +248,7 @@ ingress:
     domain: "terrakube-ui.minikube.net"
     path: "/"
     pathType: "Prefix"
+    ingressClassName: "nginx"
     tlsSecretName: tls-secret-ui-terrakube
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
@@ -256,6 +257,7 @@ ingress:
     domain: "terrakube-api.minikube.net"
     path: "/"
     pathType: "Prefix"
+    ingressClassName: "nginx"
     tlsSecretName: tls-secret-api-terrakube
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
@@ -265,6 +267,7 @@ ingress:
     domain: "terrakube-reg.minikube.net"
     path: "/"
     pathType: "Prefix"
+    ingressClassName: "nginx"
     tlsSecretName: tls-secret-reg-terrakube
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"


### PR DESCRIPTION
This PR adds the `ingressClassName` to the ingress object of ui, api and registry. This should be used instead of annotations and should fix #99 & #100 

Example: UI is configured with `ingressClassName: "nginx"` the others are how terrakube is currently handling it, which kinda doesnt work on newer version

![image](https://github.com/AzBuilder/terrakube-helm-chart/assets/11300182/b97543ea-6b47-4c99-a598-9b687a85e837)
