### PR TITLE
Allow to deploy executor as self hosted agent

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.15.2
+version: 3.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/secrets-executor.yaml
+++ b/charts/terrakube/templates/secrets-executor.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 stringData:
   # General Settings
-  AzBuilderApiUrl: 'http://terrakube-api-service:8080'
+  AzBuilderApiUrl: '{{ .Values.executor.apiServiceUrl }}'
   InternalSecret: '{{ .Values.security.internalSecret | b64enc }}'
 
   ExecutorFlagBatch: 'false'

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -272,6 +272,10 @@
             "description": "Executor Docker Version",
             "type": "string"
           },
+          "apiServiceUrl": {
+            "description": "Terrakube service where the executor will connect",
+            "type": "string"
+          },
           "replicaCount": {
             "description": "Replica count for API",
             "type": "string"

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -210,6 +210,7 @@ executor:
   serviceAccountName: ""
   resources: {}
   podLabels: {}
+  apiServiceUrl: "http://terrakube-api-service:8080"
   properties:
     toolsRepository: "https://github.com/AzBuilder/terrakube-extensions"
     toolsBranch: "main"


### PR DESCRIPTION
This will allow to deploy the executor component as a self hosted agent:

> This feature will be available from Terrakube version 2.20.0

For example to deploy a single executor agent inside namespace called "self-hosted-agent" that needs to communicate with a terrakube installation in namespace "terrakube" we can use the following:

```shell
helm install --debug --values ./your-values.yaml terrakube ./charts/terrakube/ -n self-hosted-executor
```

Helm values example:
```yaml
# Executor should be enable but we need to customize the apiServiceUrl
executor:
  enabled: true
  apiServiceUrl: "http://terrakube-api-service.terrakube:8080" ## The API is in another namespace called "terrakube"

# We need to disable the default openLdap but we need to provide the internal secret
# so the executor can authenticat with the API and the Registry
security:
  useOpenLDAP: false
  internalSecret: "AxxPdgpCi72f8WhMXCTGhtfMRp6AuBfj"

# We need to disable dex in this deployment
dex:
  enabled: false

# We need to disable default storage MINIO and set some custom values 
# in this example will be deploying like using an external MINIO
#(other backend storage could be used too)
storage:
  defaultStorage: false
  minio:
    accessKey: "admin"
    secretKey: "superadmin"
    bucketName: "terrakube"
    endpoint: "http://terrakube-minio.terrakube:9000" ## MINIO is in another namespace called "terrakube"

# We need to disable API, the default redis and default postgresql database
# But we need to provide some properties like the redis connection
api:
  enabled: false
  defaultRedis: false
  defaultDatabase: false
  properties:
    redisHostname: "terrakube-redis-master.terrakube" ## REDIS is in another namespace called "terrakube"
    redisPassword: "7p9iWVeRV4S944"

# We need to disable registry deployment
registry:
  enabled: false

# We need to disable ui deployment
ui:
  enabled: false

# We need to disable the ingress configuration
# but we need to specify the api and registry URL 
ingress:
  useTls: false
  includeTlsHosts: false
  ui:
    enabled: false
  api:
    enabled: false
    domain: "terrakube-api.minikube.net"
  registry:
    enabled: false
    domain: "terrakube-reg.minikube.net"
  dex:
    enabled: false
```

Now we are able to have as many executor components that you want:

![image](https://github.com/AzBuilder/terrakube-helm-chart/assets/4461895/a160678d-6d5e-438a-85df-13225fba5bf9)

