### PR TITLE
feat: add support for setting different secrets for environment variables.

### DIFF
--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -38,16 +38,8 @@ spec:
           {{- end }}
         envFrom:
         {{- range .Values.api.secrets }}
-          {{- if .item }}
-            - name: {{ .name }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .item.name }}
-                  key: {{ .item.key }}
-          {{- else }}
             - secretRef:
                 name: {{ .name }}
-          {{- end }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -38,14 +38,12 @@ spec:
           {{- end }}
         envFrom:
         {{- range .Values.api.secrets }}
-          {{- if .items }}
-          {{- range .items }}
+          {{- if .item }}
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.name }}
-                  key: {{ .key }}
-          {{- end }}
+                  name: {{ .item.name }}
+                  key: {{ .item.key }}
           {{- else }}
             - secretRef:
                 name: {{ .name }}

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -37,8 +37,20 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         envFrom:
-        - secretRef:
-            name: terrakube-api-secrets
+        {{- range .Values.api.secrets }}
+          {{- if .items }}
+          {{- range .items }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.name }}
+                  key: {{ .key }}
+          {{- end }}
+          {{- else }}
+            - secretRef:
+                name: {{ .name }}
+          {{- end }}
+        {{- end }}
         startupProbe:
           httpGet:
             path: /actuator/health

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -38,14 +38,12 @@ spec:
           {{- end }}
         envFrom:
         {{- range .Values.executor.secrets }}
-          {{- if .items }}
-          {{- range .items }}
+          {{- if .item }}
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.name }}
-                  key: {{ .key }}
-          {{- end }}
+                  name: {{ .item.name }}
+                  key: {{ .item.key }}
           {{- else }}
             - secretRef:
                 name: {{ .name }}

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -38,16 +38,8 @@ spec:
           {{- end }}
         envFrom:
         {{- range .Values.executor.secrets }}
-          {{- if .item }}
-            - name: {{ .name }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .item.name }}
-                  key: {{ .item.key }}
-          {{- else }}
             - secretRef:
                 name: {{ .name }}
-          {{- end }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -37,8 +37,20 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         envFrom:
-        - secretRef:
-            name: terrakube-executor-secrets
+        {{- range .Values.executor.secrets }}
+          {{- if .items }}
+          {{- range .items }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.name }}
+                  key: {{ .key }}
+          {{- end }}
+          {{- else }}
+            - secretRef:
+                name: {{ .name }}
+          {{- end }}
+        {{- end }}
         startupProbe:
           httpGet:
             path: /actuator/health

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -37,8 +37,20 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         envFrom:
-        - secretRef:
-            name: terrakube-registry-secrets
+        {{- range .Values.registry.secrets }}
+          {{- if .items }}
+          {{- range .items }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.name }}
+                  key: {{ .key }}
+          {{- end }}
+          {{- else }}
+            - secretRef:
+                name: {{ .name }}
+          {{- end }}
+        {{- end }}
         startupProbe:
           httpGet:
             path: /actuator/health

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -38,17 +38,8 @@ spec:
           {{- end }}
         envFrom:
         {{- range .Values.registry.secrets }}
-          {{- if .item }}
-            - name: {{ .name }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .item.name }}
-                  key: {{ .item.key }}
-          {{- end }}
-          {{- else }}
             - secretRef:
                 name: {{ .name }}
-          {{- end }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -38,13 +38,12 @@ spec:
           {{- end }}
         envFrom:
         {{- range .Values.registry.secrets }}
-          {{- if .items }}
-          {{- range .items }}
+          {{- if .item }}
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.name }}
-                  key: {{ .key }}
+                  name: {{ .item.name }}
+                  key: {{ .item.key }}
           {{- end }}
           {{- else }}
             - secretRef:

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -168,6 +168,8 @@ api:
   replicaCount: "1"
   serviceType: "ClusterIP"
   serviceAccountName: ""
+  secrets:
+   - terrakube-api-secrets
   resources: {}
   podLabels: {}
   defaultDatabase: true
@@ -208,6 +210,8 @@ executor:
   replicaCount: "1"
   serviceType: "ClusterIP"
   serviceAccountName: ""
+  secrets:
+   - terrakube-executor-secrets
   resources: {}
   podLabels: {}
   apiServiceUrl: "http://terrakube-api-service:8080"
@@ -225,6 +229,8 @@ registry:
   replicaCount: "1"
   serviceType: "ClusterIP"
   serviceAccountName: ""
+  secrets:
+   - terrakube-registry-secrets
   resources: {}
   podLabels: {}
   securityContext: {}


### PR DESCRIPTION
add support of setting specific environment variables. 

Making the env variables from secrets dynamic:

now variables allows setting in different ways:

example for api secrets 
```
secrets:
  - name: terrakube-api-secrets
  - name: another-secret
```


TODO:

Update json spec of variables
