### PR TITLE
Update to Terrakube 2.20.0

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -21,7 +21,7 @@ version: 3.16.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.19.2"
+appVersion: "2.20.0"
 
 dependencies:
 - name: minio

--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.16.0
+version: 3.16.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -82,6 +82,7 @@ stringData:
   DatasourceDatabase: '{{ .Values.postgresql.auth.database }}'
   DatasourceUser: '{{ .Values.postgresql.auth.username}}'
   DatasourcePassword: '{{ .Values.postgresql.auth.password }}'
+  DatasourcePort: '5432'
   ApiDataSourceType: 'POSTGRESQL'
   DatasourceSslMode: '{{ .Values.api.properties.databaseSslMode }}' 
   {{ else }}

--- a/charts/terrakube/templates/secrets-ui.yaml
+++ b/charts/terrakube/templates/secrets-ui.yaml
@@ -14,5 +14,6 @@ stringData:
       REACT_APP_REDIRECT_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}",
       REACT_APP_REGISTRY_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domain }}",
       REACT_APP_SCOPE: "{{ .Values.security.dexClientScope }}",
+      REACT_APP_TERRAKUBE_VERSION: "{{ default .Chart.AppVersion .Values.ui.version }}",
     }
 {{ end }}


### PR DESCRIPTION
- Update terrakube version
- Update default port when using the default database
- Small fix to include the UI version for future terrakube versions