### PR TITLE
Add support to change the database schema

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.16.1
+version: 3.16.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -84,6 +84,7 @@ stringData:
   DatasourcePassword: '{{ .Values.postgresql.auth.password }}'
   DatasourcePort: '5432'
   ApiDataSourceType: 'POSTGRESQL'
+  DatasourceSchema: '{{ .Values.api.properties.databaseSchema }}' 
   DatasourceSslMode: '{{ .Values.api.properties.databaseSslMode }}' 
   {{ else }}
   ApiDataSourceType: '{{ .Values.api.properties.databaseType }}'
@@ -93,6 +94,7 @@ stringData:
   DatasourcePassword: '{{ .Values.api.properties.databasePassword }}' 
   DatasourceSslMode: '{{ .Values.api.properties.databaseSslMode }}' 
   DatasourcePort: '{{ .Values.api.properties.databasePort }}' 
+  DatasourceSchema: '{{ .Values.api.properties.databaseSchema }}' 
   {{- end }}  
 
 

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -187,6 +187,7 @@ api:
     databaseHostname: ""
     databaseName: ""
     databaseUser: ""
+    databaseSchema: "public"
     databasePassword: ""
     databaseSslMode: "disable"
     databasePort: "3306"


### PR DESCRIPTION
Now we can override the schema parameter for example when using SQL AZURE like the following

```yaml
## API properties
api:
  properties:
    databaseType: "SQL_AZURE"
    databaseHostname: "xxxxx.database.windows.net"
    databaseName: "xxxxx"
    databaseUser: "xxxxx"
    databasePassword: "xxxxx"
    databaseSchema: "dbo"
```

Fix Azbuilder/terrakube#813