### PR TITLE
fix: #128 make sure the customised Dex issuer URL is used

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.17.5
+version: 3.17.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/secrets-registry.yaml
+++ b/charts/terrakube/templates/secrets-registry.yaml
@@ -14,7 +14,7 @@ stringData:
   TerrakubeEnableSecurity: 'true'
   TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
   AppClientId: '{{ .Values.security.dexClientId }}'
-  AppIssuerUri: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}/dex'
+  AppIssuerUri: '{{ .Values.dex.config.issuer }}'
 
 
   {{- if .Values.storage.defaultStorage -}}


### PR DESCRIPTION
Problem:

The /dex was hard-coded in the affect file which stop Terrakube Registry to be working with customized Dex path

This change address this by using the value of `issuer` from Dex configuration section.

This should fix #128 