### PR TITLE
feat: #127 update ingress to support multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,26 +322,25 @@ Once you have completed the above steps you can complete the file values.yaml to
 | ingress.ui.ingressClassName               | Yes      | Default is set to nginx                                                |
 | ingress.ui.useTls                         | Yes      | true/false                                                             |
 | ingress.ui.enabled                        | Yes      | true/false                                                             |
-| ingress.ui.domain                         | Yes      |                                                                        |
+| ingress.ui.domains                        | Yes      |                                                                        |
 | ingress.ui.path                           | Yes      | ImplementationSpecific/Exact/Prefix                                    |
 | ingress.ui.pathType                       | Yes      |                                                                        |
 | ingress.ui.annotations                    | Yes      | Ingress annotations                                                    |
 | ingress.api.ingressClassName              | Yes      | Default is set to nginx                                                |
 | ingress.api.useTls                        | Yes      |                                                                        |
 | ingress.api.enabled                       | Yes      |                                                                        |
-| ingress.api.domain                        | Yes      |                                                                        |
+| ingress.api.domains                       | Yes      |                                                                        |
 | ingress.api.path                          | Yes      |                                                                        |
 | ingress.api.pathType                      | Yes      | ImplementationSpecific/Exact/Prefix                                    |
 | ingress.api.annotations                   | Yes      | Ingress annotations                                                    |
 | ingress.registry.ingressClassName         | Yes      | Default is set to nginx                                                |
 | ingress.registry.useTls                   | Yes      |                                                                        |
 | ingress.registry.enabled                  | Yes      |                                                                        |
-| ingress.registry.domain                   | Yes      |                                                                        |
+| ingress.registry.domains                  | Yes      |                                                                        |
 | ingress.registry.path                     | Yes      |                                                                        |
 | ingress.registry.pathType                 | Yes      | ImplementationSpecific/Exact/Prefix                                    |
 | ingress.registry.annotations              | Yes      | Ingress annotations                                                    |
 | ingress.dex.enabled                       | Yes      |                                                                        |
-| ingress.dex.domain                        | Yes      |                                                                        |
 | ingress.dex.path                          | Yes      |                                                                        |
 | ingress.dex.pathType                      | Yes      | ImplementationSpecific/Exact/Prefix                                    |
 | ingress.dex.annontations                  | Yes      | Ingress annotations                                                    |

--- a/charts/terrakube/templates/ingress-api.yaml
+++ b/charts/terrakube/templates/ingress-api.yaml
@@ -12,39 +12,45 @@ spec:
   {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:
-    - {{ .Values.ingress.api.domain | quote }}
+    {{- range .Values.ingress.api.domains }}
+    - {{ . | quote }}
+    {{- end }}
     secretName: {{ .Values.ingress.api.tlsSecretName }}
   {{ end }}
   {{- if and .Values.ingress.api.enabled .Values.ingress.dex.enabled .Values.ingress.dex.enabled  }}
   rules:
-  - host: {{ .Values.ingress.api.domain | quote }}
+  {{- range .Values.ingress.api.domains }}
+  - host: {{ . | quote }}
     http:
       paths:
-      - path: {{ .Values.ingress.api.path | quote }}
-        pathType: {{ .Values.ingress.api.pathType | quote }}
+      - path: {{ $.Values.ingress.api.path | quote }}
+        pathType: {{ $.Values.ingress.api.pathType | quote }}
         backend:
           service:
             name: terrakube-api-service
             port:
               number: 8080
-      - path: {{ .Values.ingress.dex.path | quote }}
-        pathType: {{ .Values.ingress.dex.pathType | quote }}
+      - path: {{ . | quote }}
+        pathType: {{ $.Values.ingress.dex.pathType | quote }}
         backend:
           service:
-            name: {{ .Release.Name }}-dex
+            name: {{ .Release.name }}-dex
             port:
               number: 5556
+      {{- end }}
   {{ else }}
   rules:
-  - host: {{ .Values.ingress.api.domain | quote }}
+  {{- range .Values.ingress.api.domains }}
+  - host: {{ . | quote }}
     http:
       paths:
-      - path: {{ .Values.ingress.api.path | quote }}
-        pathType: {{ .Values.ingress.api.pathType | quote }}
+      - path: {{ $.Values.ingress.api.path | quote }}
+        pathType: {{ $.Values.ingress.api.pathType | quote }}
         backend:
           service:
             name: terrakube-api-service
             port:
               number: 8080
+  {{- end }}
   {{ end }}
 {{ end }}

--- a/charts/terrakube/templates/ingress-registry.yaml
+++ b/charts/terrakube/templates/ingress-registry.yaml
@@ -12,18 +12,22 @@ spec:
   {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:
-    - {{ .Values.ingress.registry.domain | quote}}
+    {{- range .Values.ingress.registry.domains }}
+    - {{ . | quote}}
+    {{- end }}
     secretName: {{ .Values.ingress.registry.tlsSecretName }}
   {{ end }}
   rules:
-  - host:  {{ .Values.ingress.registry.domain | quote}}
+  {{- range .Values.ingress.registry.domains }}
+  - host:  {{ . | quote}}
     http:
       paths:
-      - path: {{ .Values.ingress.registry.path | quote }}
-        pathType: {{ .Values.ingress.registry.pathType | quote }}
+      - path: {{ $.Values.ingress.registry.path | quote }}
+        pathType: {{ $.Values.ingress.registry.pathType | quote }}
         backend:
           service:
             name: terrakube-registry-service
             port:
               number: 8075
+  {{- end }}
 {{ end }}

--- a/charts/terrakube/templates/ingress-ui.yaml
+++ b/charts/terrakube/templates/ingress-ui.yaml
@@ -9,21 +9,25 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ default "nginx" .Values.ingress.ui.ingressClassName }}
-  {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
+  {{- if and .Values.ingress.useTls .Values.ingress.includeTlsHosts }}
   tls:
   - hosts:
-    - {{ .Values.ingress.ui.domain | quote }}
+    {{- range .Values.ingress.ui.domains }}
+    - {{ . | quote }}
+    {{- end }}
     secretName: {{ .Values.ingress.ui.tlsSecretName }}
-  {{ end }}
+  {{- end }}
   rules:
-  - host:  {{ .Values.ingress.ui.domain | quote }}
+  {{- range .Values.ingress.ui.domains }}
+  - host:  {{ . | quote }}
     http:
       paths:
-      - path: {{ .Values.ingress.ui.path | quote }}
-        pathType: {{ .Values.ingress.ui.pathType | quote }}
+      - path: {{ $.Values.ingress.ui.path | quote }}
+        pathType: {{ $.Values.ingress.ui.pathType | quote }}
         backend:
           service:
             name: terrakube-ui-service
             port:
               number: 8080
+  {{- end }}
 {{ end }}

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -12,9 +12,9 @@ stringData:
   InternalSecret: '{{ .Values.security.internalSecret | b64enc }}'
   DexIssuerUri: '{{ .Values.dex.config.issuer }}'
   DexClientId: '{{ .Values.security.dexClientId }}'
-  TerrakubeHostname: '{{ .Values.ingress.api.domain }}'
+  TerrakubeHostname: '{{ .Values.ingress.api.domains | first }}'
   AzBuilderExecutorUrl: 'http://terrakube-executor-service:8090/api/v1/terraform-rs'
-  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
+  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domains | first }}'
   TERRAKUBE_ADMIN_GROUP: '{{ .Values.security.adminGroup }}'
   TerrakubeRedisPort: '6379'
   {{- if .Values.api.defaultRedis -}}

--- a/charts/terrakube/templates/secrets-executor.yaml
+++ b/charts/terrakube/templates/secrets-executor.yaml
@@ -14,8 +14,8 @@ stringData:
   TerrakubeToolsRepository: '{{ .Values.executor.properties.toolsRepository }}'
   TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
   TerrakubeEnableSecurity: 'true'
-  TerrakubeRegistryDomain: '{{ .Values.ingress.registry.domain }}'
-  TerrakubeApiUrl: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}'
+  TerrakubeRegistryDomain: '{{ .Values.ingress.registry.domains | first }}'
+  TerrakubeApiUrl: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domains | first }}'
   TerrakubeRedisPort: '6379'
   {{- if .Values.api.defaultRedis -}}
   #Default Redis

--- a/charts/terrakube/templates/secrets-registry.yaml
+++ b/charts/terrakube/templates/secrets-registry.yaml
@@ -5,16 +5,16 @@ metadata:
   name: terrakube-registry-secrets
 type: Opaque
 stringData:
-  AzBuilderRegistry: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domain }}'
+  AzBuilderRegistry: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domains | first}}'
   AzBuilderApiUrl: 'http://terrakube-api-service:8080'
   AuthenticationValidationTypeRegistry: 'DEX'
   PatSecret: '{{ .Values.security.patSecret | b64enc}}'
   InternalSecret: '{{ .Values.security.internalSecret | b64enc }}'
   DexIssuerUri: '{{ .Values.dex.config.issuer }}'
   TerrakubeEnableSecurity: 'true'
-  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
+  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domains | first }}'
   AppClientId: '{{ .Values.security.dexClientId }}'
-  AppIssuerUri: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}/dex'
+  AppIssuerUri: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domains | first }}/dex'
 
 
   {{- if .Values.storage.defaultStorage -}}

--- a/charts/terrakube/templates/secrets-ui.yaml
+++ b/charts/terrakube/templates/secrets-ui.yaml
@@ -8,11 +8,11 @@ stringData:
   # This UI configuration file is loaded in /app/env-config.js
   env-config.js: |
     window._env_ = {
-      REACT_APP_TERRAKUBE_API_URL: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}/api/v1/",
+      REACT_APP_TERRAKUBE_API_URL: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domains | first }}/api/v1/",
       REACT_APP_CLIENT_ID: "{{ .Values.security.dexClientId }}",
       REACT_APP_AUTHORITY: "{{ .Values.dex.config.issuer }}",
-      REACT_APP_REDIRECT_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}",
-      REACT_APP_REGISTRY_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domain }}",
+      REACT_APP_REDIRECT_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domains | first }}",
+      REACT_APP_REGISTRY_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domains | first }}",
       REACT_APP_SCOPE: "{{ .Values.security.dexClientScope }}",
       REACT_APP_TERRAKUBE_VERSION: "{{ default .Chart.AppVersion .Values.ui.version }}",
     }

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -446,7 +446,7 @@
       },
       "ingress": {
         "type": "object",
-        "required": ["ui", "api", "registry", "useTls"],
+        "required": ["ui", "domains", "api", "registry", "useTls"],
         "properties": {
           "useTls": {
             "description": "Enable Https Ingress",
@@ -464,9 +464,12 @@
                 "description": "Enable ingress UI",
                 "type": "boolean"
               },
-              "domain": {
-                "description": "UI domain",
-                "type": "string"
+              "domains": {
+                "description": "UI domains",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "path": {
                 "description": "Ingress UI path",
@@ -483,15 +486,18 @@
           },
           "api": {
             "type": "object",
-            "required": ["enabled", "domain", "annotations", "path", "pathType"],
+            "required": ["enabled", "domains", "annotations", "path", "pathType"],
             "properties": {
               "enabled": {
                 "description": "Enable ingress API",
                 "type": "boolean"
               },
-              "domain": {
-                "description": "API domain",
-                "type": "string"
+              "domains": {
+                "description": "API domains",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "path": {
                 "description": "Ingress API path",
@@ -529,15 +535,17 @@
           },
           "registry": {
             "type": "object",
-            "required": ["enabled", "annotations", "path", "pathType"],
+            "required": ["enabled", "domains", "annotations", "path", "pathType"],
             "properties": {
               "enabled": {
                 "description": "Enable ingress UI",
                 "type": "boolean"
               },
-              "domain": {
-                "description": "Registry domain",
-                "type": "string"
+              "domains": {
+                "description": "Registry domains",
+                "type": "array",
+                "items": {
+                  "type": "string"
               },
               "path": {
                 "description": "Ingress registry path",

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -260,11 +260,13 @@ ui:
 
 ## Ingress properties
 ingress:
-  useTls: false
+  useTls: true
   includeTlsHosts: true
   ui:
     enabled: true
-    domain: "terrakube-ui.minikube.net"
+    domains: 
+    - "terrakube-ui.minikube.net"
+    - "terrakube-ui.example.net"
     path: "/"
     pathType: "Prefix"
     ingressClassName: "nginx"
@@ -273,7 +275,9 @@ ingress:
       nginx.ingress.kubernetes.io/use-regex: "true"
   api:
     enabled: true
-    domain: "terrakube-api.minikube.net"
+    domains: 
+    - "terrakube-api.minikube.net"
+    - "terrakube-api.example.net"
     path: "/"
     pathType: "Prefix"
     ingressClassName: "nginx"
@@ -283,7 +287,9 @@ ingress:
       nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header Authorization $http_authorization;"
   registry:
     enabled: true
-    domain: "terrakube-reg.minikube.net"
+    domains: 
+    - "terrakube-reg.minikube.net"
+    - "terrakube-reg.example.net"
     path: "/"
     pathType: "Prefix"
     ingressClassName: "nginx"

--- a/examples/AzureAuthentication-Example1.md
+++ b/examples/AzureAuthentication-Example1.md
@@ -73,7 +73,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
+    domains: 
+    - "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -82,7 +83,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
+    domains: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -92,7 +94,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
+    domains: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:

--- a/examples/AzureAuthentication-Example2.md
+++ b/examples/AzureAuthentication-Example2.md
@@ -86,7 +86,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
+    domain: 
+    - "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -95,7 +96,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
+    domain: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -105,7 +107,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
+    domain: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:

--- a/examples/AzureAuthentication-Example3.md
+++ b/examples/AzureAuthentication-Example3.md
@@ -86,7 +86,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
+    domain: 
+    - "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -95,7 +96,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
+    domain: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -105,7 +107,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
+    domain: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations:

--- a/examples/AzureAuthentication-Example4.md
+++ b/examples/AzureAuthentication-Example4.md
@@ -85,7 +85,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
+    domains: 
+    - "<<CHANGE_THIS>>" # Change this to your Terrakube UI URL for example terrakube.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations: # This annotations can change based on requirements. The followin is an example using EKS
@@ -101,7 +102,8 @@ ingress:
       kubernetes.io/ingress.class: alb
   api:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
+    domains: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube api url for example terrakube-api.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations: # This annotations can change based on requirements. The followin is an example using EKS
@@ -117,7 +119,8 @@ ingress:
       kubernetes.io/ingress.class: alb
   registry:
     enabled: true
-    domain: "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
+    domains: 
+    - "<<CHANGE_THIS>>" # Change this to your terrakube registry url for example terrakube-registry.example.com
     path: "/(.*)"
     pathType: "Prefix"
     annotations: # This annotations can change based on requirements. The followin is an example using EKS

--- a/examples/CognitoAuthentication-Example1.md
+++ b/examples/CognitoAuthentication-Example1.md
@@ -94,7 +94,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "terrakube-ui.yourdomain.com"
+    domains: 
+    - "terrakube-ui.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -103,7 +104,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "terrakube-api.yourdomain.com"
+    domains: 
+    - "terrakube-api.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -113,7 +115,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "terrakube-reg.yourdomain.com"
+    domains: 
+    - "terrakube-reg.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:

--- a/examples/GithubAuthentication-Example1.md
+++ b/examples/GithubAuthentication-Example1.md
@@ -75,7 +75,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "terrakube-ui.domain.com" # Change for your real domain
+    domains: 
+    - "terrakube-ui.domain.com" # Change for your real domain
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -84,7 +85,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "terrakube-api.domain.com" # Change for your real domain
+    domains: 
+    - "terrakube-api.domain.com" # Change for your real domain
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -94,7 +96,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "terrakube-reg.domain.com" # Change for your real domain
+    domains: 
+    - "terrakube-reg.domain.com" # Change for your real domain
     path: "/(.*)"
     pathType: "Prefix"
     annotations:

--- a/examples/GoogleAuthentication-Example1.md
+++ b/examples/GoogleAuthentication-Example1.md
@@ -100,7 +100,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "terrakube-ui.yourdomain.com"
+    domains: 
+    - "terrakube-ui.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -109,7 +110,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "terrakube-api.yourdomain.com"
+    domains: 
+    - "terrakube-api.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -119,7 +121,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "terrakube-reg.yourdomain.com"
+    domains: 
+    - "terrakube-reg.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:

--- a/examples/GoogleAuthentication-Example2.md
+++ b/examples/GoogleAuthentication-Example2.md
@@ -114,7 +114,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "terrakube-ui.yourdomain.com"
+    domains: 
+    - "terrakube-ui.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -123,7 +124,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "terrakube-api.yourdomain.com"
+    domains: 
+    - "terrakube-api.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -133,7 +135,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "terrakube-reg.yourdomain.com"
+    domains: 
+    - "terrakube-reg.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:

--- a/examples/GoogleAuthentication-Example3.md
+++ b/examples/GoogleAuthentication-Example3.md
@@ -114,7 +114,8 @@ ingress:
   useTls: true
   ui:
     enabled: true
-    domain: "terrakube-ui.yourdomain.com"
+    domains: 
+    - "terrakube-ui.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -123,7 +124,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   api:
     enabled: true
-    domain: "terrakube-api.yourdomain.com"
+    domains: 
+    - "terrakube-api.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:
@@ -133,7 +135,8 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt
   registry:
     enabled: true
-    domain: "terrakube-reg.yourdomain.com"
+    domains: 
+    - "terrakube-reg.yourdomain.com"
     path: "/(.*)"
     pathType: "Prefix"
     annotations:


### PR DESCRIPTION
The existing ingresses accept only one domain for each of ui, api and registry.

This change adds support of multiple domains for each of the ingresses, however by changing parameter `domnain` to `domains` for the ingress configurations.

Additional changes:

1. Remove documentation for domain used by Dex. `ingress.dex.domain` to be specific. The Dex shares the same domains as the API endpoints

support #127 