### PR TITLE
Support to create service account and role bindings 

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.18.0
+version: 3.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -43,7 +43,7 @@ spec:
         envFrom:
         {{- range .Values.api.secrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . | quote }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -43,7 +43,7 @@ spec:
         envFrom:
         {{- range .Values.executor.secrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . | quote }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -43,7 +43,7 @@ spec:
         envFrom:
         {{- range .Values.registry.secrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . | quote }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/rbac-api.yaml
+++ b/charts/terrakube/templates/rbac-api.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.api.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.api.serviceAccountName }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.api.rbac.roleName }}
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.api.rbac.roleBindingName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.api.serviceAccountName }}
+roleRef:
+  kind: Role
+  name: {{ .Values.api.rbac.roleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -177,6 +177,10 @@ api:
   replicaCount: "1"
   serviceType: "ClusterIP"
   serviceAccountName: ""
+  rbac:
+    create: false
+    roleName: "terrakube-api-role"
+    roleBindingName: "terrakube-api-role-binding"
   secrets:
    - terrakube-api-secrets
   resources: {}


### PR DESCRIPTION
This will add support to create the service account and role bindings to use the [ephemeral agent support](https://docs.terrakube.io/getting-started/deployment/ephemeral-agents).

To use it we need to  use the following values for the helm chart:

```yaml
api:
  serviceAccountName: "terrakube-api-service-account"
  rbac:
    create: true
    roleName: "terrakube-api-role"
    roleBindingName: "terrakube-api-role-binding"
```

> By default this will be disable.

Fix #132 