### PR TITLE
Pod-Annotations-For-Executor

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.20.0
+version: 3.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets-executor.yaml") . | sha256sum }}
         {{- with .Values.executor.podAnnotations }}
-        {{- toYaml. | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.executor.imagePullSecrets | default .Values.global.imagePullSecrets }}

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -19,6 +19,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets-executor.yaml") . | sha256sum }}
+        {{- with .Values.executor.podAnnotations }}
+        {{- toYaml. | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.executor.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -302,6 +302,9 @@
           "podLabels": {
             "type": "object"
           },
+          "podAnnotations": {
+            "type": "object"
+          },
           "env": {
             "type": "array",
             "items": {

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -231,6 +231,7 @@ executor:
    - terrakube-executor-secrets
   resources: {}
   podLabels: {}
+  podAnnotations: {}
   apiServiceUrl: "http://terrakube-api-service:8080"
   properties:
     toolsRepository: "https://github.com/AzBuilder/terrakube-extensions"


### PR DESCRIPTION
Adding Ability to add pod annotations to executors. This provides the following benefits
- attach annotations controllers listens for to attach side cars (ie. Vault Sidecar Controller, or prometheus metrics)