### PR TITLE
feat: Make executorUrl customisable

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.23.1
+version: 3.23.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/ingress-executor.yaml
+++ b/charts/terrakube/templates/ingress-executor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.executor.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: terrakube-executor-ingress
+  {{- with .Values.ingress.executor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ default "nginx" .Values.ingress.executor.ingressClassName }}
+  {{ if and .Values.ingress.useTls .Values.ingress.includeTlsHosts -}}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.executor.domain | quote }}
+    secretName: {{ .Values.ingress.executor.tlsSecretName }}
+  {{ end }}
+  rules:
+  - host:  {{ .Values.ingress.executor.domain | quote }}
+    http:
+      paths:
+      - path: {{ .Values.ingress.executor.path | quote }}
+        pathType: {{ .Values.ingress.executor.pathType | quote }}
+        backend:
+          service:
+            name: terrakube-executor-service
+            port:
+              number: 8090
+{{ end }}

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -13,7 +13,7 @@ stringData:
   DexIssuerUri: '{{ .Values.dex.config.issuer }}'
   DexClientId: '{{ .Values.security.dexClientId }}'
   TerrakubeHostname: '{{ .Values.ingress.api.domain }}'
-  AzBuilderExecutorUrl: 'http://terrakube-executor-service:8090/api/v1/terraform-rs'
+  AzBuilderExecutorUrl: '{{ .Values.api.properties.executorUrl }}/api/v1/terraform-rs'
   ExecutorReplicas: '{{ .Values.api.properties.executorReplicaCount |  default .Values.executor.replicaCount }}'
   TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
   TERRAKUBE_ADMIN_GROUP: '{{ .Values.security.adminGroup }}'

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -223,6 +223,7 @@ api:
     redisHostname: ""
     redisPassword: ""
     redisPort: "6379"
+    executorUrl: "http://terrakube-executor-service:8090"
 
 
 ## The database port is only used for mysql databases
@@ -338,3 +339,12 @@ ingress:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header Authorization $http_authorization;"
+  executor:
+    enabled: true
+    domain: "terrakube-executor.minikube.net"
+    path: "/"
+    pathType: "Prefix"
+    ingressClassName: "nginx"
+    tlsSecretName: tls-secret-executor-terrakube    
+    annotations:
+      nginx.ingress.kubernetes.io/use-regex: "true"

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -340,7 +340,7 @@ ingress:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header Authorization $http_authorization;"
   executor:
-    enabled: true
+    enabled: false
     domain: "terrakube-executor.minikube.net"
     path: "/"
     pathType: "Prefix"


### PR DESCRIPTION
Some Kubernetes clusters use "random" as the routing mechanism for service, which doesn't distribute the TF jobs to executor endpoints evenly.

This change makes the executor URL customisable and also add an ingress for executor if needed. Normal cloud load balancers has more routing mechanisms which are also easy to change.