### PR TITLE
feat(helm): allow customizing api automountServiceAccountToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Once you have completed the above steps you can complete the file values.yaml to
 | api.version                               | Yes      | Terrakube API version                                                  |
 | api.replicaCount                          | Yes      |                                                                        |
 | api.serviceAccountName                    | No       | Kubernetes Service Account name                                        |
+| api.automountServiceAccountToken          | No       | Enable automountServiceAccountToken                                    | 
 | api.serviceType                           | Yes      |                                                                        |
 | api.env                                   | No       |                                                                        |
 | api.volumes                               | No       |                                                                        |

--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.27.4
+version: 3.27.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -105,6 +105,9 @@ spec:
       {{- with .Values.api.serviceAccountName }}
       serviceAccountName: {{ quote . }}
       {{- end }}
+      {{- with .Values.api.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ . }}
+      {{- end }}
       {{- with .Values.api.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/terrakube/templates/rbac-api.yaml
+++ b/charts/terrakube/templates/rbac-api.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Values.api.serviceAccountName }}
   labels:
     {{- include "terrakube.labels" . | nindent 4 }}
+{{- with .Values.api.automountServiceAccountToken }}
+automountServiceAccountToken: {{ . }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -179,6 +179,7 @@ api:
   replicaCount: "1"
   serviceType: "ClusterIP"
   serviceAccountName: ""
+  automountServiceAccountToken: true
   otel:
     enabled: false
     metrics:


### PR DESCRIPTION
In high security environments there are policies requiring automountServiceAccountToken: false.

This change allows customizing the value. 